### PR TITLE
Dockerize pandafium build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM lambci/lambda:build-python2.7
+
+RUN yum install -y git-all libjpeg-turbo-devel libjpeg-turbo-static freetype-devel
+
+WORKDIR /opt
+RUN mkdir depot_tools
+RUN chown ec2-user depot_tools
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+RUN echo 'export PATH=/opt/depot_tools:"$PATH"' >> ~/.bashrc
+ENV PATH="/opt/depot_tools:${PATH}"
+
+RUN mkdir /root/repo
+WORKDIR /root/repo
+RUN gclient config --unmanaged https://github.com/gradescope/pdfium.git && gclient sync
+WORKDIR /root/repo/pdfium
+RUN git checkout pandafium
+RUN gclient sync
+
+RUN build/linux/sysroot_scripts/install-sysroot.py --arch=amd64
+RUN gn gen out/Lambda
+ADD args.gn out/Lambda
+
+RUN ninja -C out/Lambda

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,4 @@ RUN ninja -C out/Lambda samples:pandafium
 # Multistage build
 FROM lambci/lambda:build-python2.7
 COPY --from=0 /root/repo/pdfium/out/Lambda/pandafium /usr/local/bin/pandafium
+CMD pandafium

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN gn gen out/Lambda
 ADD args.gn out/Lambda
 RUN gn gen out/Lambda
 
-CMD ninja -C out/Lambda samples:pdfium
+CMD ninja -C out/Lambda samples:pandafium

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,12 @@ RUN mkdir /root/repo
 WORKDIR /root/repo
 RUN gclient config --unmanaged https://github.com/gradescope/pdfium.git && gclient sync
 WORKDIR /root/repo/pdfium
-RUN git checkout pandafium
+RUN git fetch && git checkout ibrahim/dockerize-build
 RUN gclient sync
 
 RUN build/linux/sysroot_scripts/install-sysroot.py --arch=amd64
 RUN gn gen out/Lambda
 ADD args.gn out/Lambda
+RUN gn gen out/Lambda
 
-RUN ninja -C out/Lambda
+CMD ninja -C out/Lambda samples:pdfium

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,8 @@ RUN gn gen out/Lambda
 ADD args.gn out/Lambda
 RUN gn gen out/Lambda
 
-CMD ninja -C out/Lambda samples:pandafium
+RUN ninja -C out/Lambda samples:pandafium
+
+# Multistage build
+FROM lambci/lambda:build-python2.7
+COPY --from=0 /root/repo/pdfium/out/Lambda/pandafium /usr/local/bin/pandafium

--- a/args.gn
+++ b/args.gn
@@ -1,0 +1,12 @@
+use_goma = false                  # Googlers only.
+is_debug = false                  # Enable debugging features.
+pdf_use_skia = false              # Set true to enable experimental skia backend.
+
+pdf_is_standalone = true          # Set for a non-embedded build.
+is_component_build = false        # Disable component build (must be false)
+clang_use_chrome_plugins = false  # Currently must be false.
+use_sysroot = false               # Currently must be false on Linux.
+
+pdf_enable_xfa = false            # Set false to remove XFA support (implies JS support).
+pdf_enable_v8 = false             # Set false to remove Javascript support.
+is_clang = false                  # Compile with gcc

--- a/samples/BUILD.gn
+++ b/samples/BUILD.gn
@@ -109,6 +109,6 @@ executable("pandafium") {
 
   #cflags_cc = [ "-stdlib=libc++" ]
   deps += [ "../third_party:fx_lpng" ]
-  libs = [ "/usr/lib/x86_64-linux-gnu/libjpeg.a" ]
+  libs = [ "/usr/lib64/libjpeg.a"]
   configs += [ ":pdfium_samples_config" ]
 }

--- a/third_party/libjpegturbo/jconfig.h
+++ b/third_party/libjpegturbo/jconfig.h
@@ -2,7 +2,7 @@
 /* Version ID for the JPEG library.
  * Might be useful for tests like "#if JPEG_LIB_VERSION >= 60".
  */
-#define JPEG_LIB_VERSION 80
+#define JPEG_LIB_VERSION 62
 
 /* libjpeg-turbo version */
 #define LIBJPEG_TURBO_VERSION 1.3.0


### PR DESCRIPTION
Fixes some misconfiguration issues (particularly trying to use libjpeg's JPEG8 API instead of the JPEG6 version that the system version of libjpeg-turbo installs).

This builds a version that should work on Amazon Lambda/Amazon Linux.