### PR TITLE
Transparent PDFs should not render with a black background

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-python2.7
+FROM lambci/lambda:build-python2.7 as build-environment
 
 RUN yum install -y git-all libjpeg-turbo-devel libjpeg-turbo-static freetype-devel
 
@@ -25,5 +25,5 @@ RUN ninja -C out/Lambda samples:pandafium
 
 # Multistage build
 FROM lambci/lambda:build-python2.7
-COPY --from=0 /root/repo/pdfium/out/Lambda/pandafium /usr/local/bin/pandafium
+COPY --from=build-environment /root/repo/pdfium/out/Lambda/pandafium /usr/local/bin/pandafium
 CMD pandafium

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN mkdir /root/repo
 WORKDIR /root/repo
 RUN gclient config --unmanaged https://github.com/gradescope/pdfium.git && gclient sync
 WORKDIR /root/repo/pdfium
-RUN git fetch && git checkout ibrahim/dockerize-build
+
+ARG revision=pandafium
+RUN git fetch && git checkout $revision
 RUN gclient sync
 
 RUN build/linux/sysroot_scripts/install-sysroot.py --arch=amd64

--- a/samples/pandafium.cc
+++ b/samples/pandafium.cc
@@ -234,13 +234,6 @@ static void WriteJpg(const char* pdf_name, int num, const void* buffer_void,
    * since the defaults depend on the source color space.)
    */
 
-  // Convert pixels with opacity set to 0 (i.e. transparent) to white
-  for(int i = 0; i < width * height * 4; i += 4){
-    if(image_buffer[i+3] == 0){ // Pixel is completely transparent
-      image_buffer[i] = image_buffer[i+1] = image_buffer[i+2] = 255;
-    }
-  };
-
   jpeg_set_defaults(&cinfo);
 
   jpeg_start_compress(&cinfo, TRUE);
@@ -248,6 +241,13 @@ static void WriteJpg(const char* pdf_name, int num, const void* buffer_void,
   row_stride = image_width * 4; /* JSAMPLEs per row in image_buffer */
 
   while (cinfo.next_scanline < cinfo.image_height) {
+      // Convert pixels with opacity set to 0 (i.e. transparent) to white
+      int row_base = cinfo.next_scanline * row_stride;
+      for(int i = row_base; i < row_base + row_stride; i += 4) {
+          if(image_buffer[i+3] == 0){ // Pixel is completely transparent
+              image_buffer[i] = image_buffer[i+1] = image_buffer[i+2] = 255;
+          }
+      }
       /* jpeg_write_scanlines expects an array of pointers to scanlines.
        * Here the array is only one element long, but you could pass
        * more than one scanline at a time if that's more convenient.

--- a/samples/pandafium.cc
+++ b/samples/pandafium.cc
@@ -223,16 +223,24 @@ static void WriteJpg(const char* pdf_name, int num, const void* buffer_void,
   /* Now we can initialize the JPEG compression object. */
   jpeg_create_compress(&cinfo);
   jpeg_stdio_dest(&cinfo, fp);
-  // Source data is B, G, R, unused.
+  // Source data is B, G, R, alpha.
   // Dest data is R, G, B.
   cinfo.image_width = image_width;      /* image width and height, in pixels */
   cinfo.image_height = image_height;
   cinfo.input_components = 4;           /* # of color components per pixel */
-  cinfo.in_color_space = JCS_EXT_BGRX;       /* colorspace of input image */
+  cinfo.in_color_space = JCS_EXT_BGRA;       /* colorspace of input image */
   /* Now use the library's routine to set default compression parameters.
    * (You must set at least cinfo.in_color_space before calling this,
    * since the defaults depend on the source color space.)
    */
+
+  // Convert pixels with opacity set to 0 (i.e. transparent) to white
+  for(int i = 0; i < width * height * 4; i += 4){
+    if(image_buffer[i+3] == 0){ // Pixel is completely transparent
+      image_buffer[i] = image_buffer[i+1] = image_buffer[i+2] = 255;
+    }
+  };
+
   jpeg_set_defaults(&cinfo);
 
   jpeg_start_compress(&cinfo, TRUE);

--- a/samples/pandafium.cc
+++ b/samples/pandafium.cc
@@ -233,7 +233,6 @@ static void WriteJpg(const char* pdf_name, int num, const void* buffer_void,
    * (You must set at least cinfo.in_color_space before calling this,
    * since the defaults depend on the source color space.)
    */
-
   jpeg_set_defaults(&cinfo);
 
   jpeg_start_compress(&cinfo, TRUE);


### PR DESCRIPTION
Some PDF generators are producing (0, 0, 0, 0) pixels, which gets turned
into black when you drop the alpha channel, since JPEG does not support
transparency. This will convert all such pixels to white.

This particularly seems to affect PDFs from iOS 13.