### PR TITLE
Start out with the desired pdfium revision

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,11 @@ ENV PATH="/opt/depot_tools:${PATH}"
 
 RUN mkdir /root/repo
 WORKDIR /root/repo
-RUN gclient config --unmanaged https://github.com/gradescope/pdfium.git && gclient sync
-WORKDIR /root/repo/pdfium
-
 ARG revision=pandafium
-RUN git fetch && git checkout $revision
+RUN gclient config --unmanaged --name pdfium https://github.com/gradescope/pdfium.git@origin/$revision
 RUN gclient sync
+
+WORKDIR /root/repo/pdfium
 
 RUN build/linux/sysroot_scripts/install-sysroot.py --arch=amd64
 RUN gn gen out/Lambda


### PR DESCRIPTION
Something about the way Docker layers works causes these annoying
errors if you check out one revision and then try to check out a
different branch in a later step.

Starting out with the desired revision seems more sensible anyhow.

```
  File "/opt/depot_tools/metrics.py", line 267, in print_notice_and_exit
    yield
  File "/opt/depot_tools/gclient.py", line 3182, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/opt/depot_tools/gclient.py", line 3168, in main
    return dispatcher.execute(OptionParser(), argv)
  File "/opt/depot_tools/subcommand.py", line 252, in execute
    return command(parser, args[1:])
  File "/opt/depot_tools/gclient.py", line 2725, in CMDsync
    ret = client.RunOnDeps('update', args)
  File "/opt/depot_tools/gclient.py", line 1786, in RunOnDeps
    self._RemoveUnversionedGitDirs()
  File "/opt/depot_tools/gclient.py", line 1664, in _RemoveUnversionedGitDirs
    os.rename(os.path.join(e_dir, '.git'), save_dir)
OSError: [Errno 18] Invalid cross-device link
```