### PR TITLE
Copy in working directory when building pandafium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,12 @@ WORKDIR /root/repo
 
 RUN gclient config --unmanaged --name pdfium https://github.com/gradescope/pdfium.git
 ADD . / pdfium/
-RUN gclient sync
 
 WORKDIR /root/repo/pdfium
+ARG revision=HEAD
+RUN git remote set-url origin https://github.com/gradescope/pdfium.git
+RUN git fetch && git checkout $revision
+RUN gclient sync
 
 RUN build/linux/sysroot_scripts/install-sysroot.py --arch=amd64
 RUN gn gen out/Lambda

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ ENV PATH="/opt/depot_tools:${PATH}"
 
 RUN mkdir /root/repo
 WORKDIR /root/repo
-ARG revision=pandafium
-RUN gclient config --unmanaged --name pdfium https://github.com/gradescope/pdfium.git@origin/$revision
+
+RUN gclient config --unmanaged --name pdfium https://github.com/gradescope/pdfium.git
+ADD . / pdfium/
 RUN gclient sync
 
 WORKDIR /root/repo/pdfium


### PR DESCRIPTION
Allows building local changes without having to push them up to GitHub.

This will also fix Dockerhub autotests - right now it is always building the `pandafium` branch so it's meaningless.